### PR TITLE
Fix library's name on bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An ultra-light, configurable HTML toast messages suitable for your webapp.
 
 ```npm install toastit.js```
-```bower install toastit.js```
+```bower install toastit```
 
 ## Demo
 


### PR DESCRIPTION
Got `$ bower ENOTFOUND Package toastit.js not found`, but when I removed _.js_ it installed fine. But I could be wrong ;)
